### PR TITLE
ead2002toEADx.xsl: default value 'xxx' is not facet-valid with respect to enumeration

### DIFF
--- a/ead2002toEADx.xsl
+++ b/ead2002toEADx.xsl
@@ -13,9 +13,17 @@
     </xd:doc>
     <xsl:output encoding="UTF-8" indent="yes" method="xml"/>
 
-    <!-- user paratmter for contorl/eventType -->
+    <!-- user parameter for control/eventType -->
     <!-- eventType enumeration '[created, revised, deleted, cancelled, derived, updated]'.  -->
     <xsl:param name="eventType" select="'derived'"/>
+
+    <!-- user parameter for control/agentType -->
+    <!-- enumeration '[human, machine]' -->
+    <xsl:param name="agentType" select="'machine'"/>
+
+    <!-- user parameter for control/publicationStatus -->
+    <!-- enumeration '[inProcess, approved]' -->
+    <xsl:param name="publicationStatus" select="'inProcess'"/>
 
     <xsl:variable name="instance-ns-stripped">
         <xsl:apply-templates select="/" mode="strip-ns"/>
@@ -125,7 +133,7 @@
             <maintenanceEvent>
                 <eventType><xsl:value-of select="$eventType"/></eventType>
                 <eventDateTime>xxx</eventDateTime>
-                <agentType>xxx</agentType>
+                <agentType><xsl:value-of select="$agentType"/></agentType>
                 <agent>xxx</agent>
             </maintenanceEvent>
         </descriptionMaintenanceHistory>
@@ -141,7 +149,7 @@
             <language languageCode="eng">xxx</language>
             <script scriptCode="Latn">xxx</script>
         </languageDeclaration>
-        <publicationStatus>xxx</publicationStatus>
+        <publicationStatus><xsl:value-of select="$publicationStatus"/></publicationStatus>
     </control>
 </xsl:template>
     


### PR DESCRIPTION
adds parameters to the xslt with default value for  `<control>` sub-elements that are valid with with respect to their enumerations.

currently, the output looks like this

``` xml
<control>
...
<eventType>xxx</eventType>
...
<agent>xxx</agent>
...
<publicationStatus>xxx</publicationStatus>
...
</control>
```

`eventType` default is `derived` 
`agentType` default is `machine`
`publicationStatus` default is `inProcess`

But, I missed up and forgot to branch ... so this pull request has the fix for the xmlns issue in it as well...
