### PR TITLE
Issue 512

### DIFF
--- a/ead3.rng
+++ b/ead3.rng
@@ -722,7 +722,7 @@
       </optional>
       <optional>
         <attribute name="containerid">
-          <data type="NMTOKEN"/>
+          <data type="string"/>
         </attribute>
       </optional>
       <ref name="m.mixed.basic"/>

--- a/inprocess/ead_revised_defs.rng
+++ b/inprocess/ead_revised_defs.rng
@@ -678,7 +678,7 @@
       </optional>
       <optional>
         <attribute name="containerid">
-          <data type="NMTOKEN"/>
+          <data type="string"/>
         </attribute>
       </optional>
       <ref name="m.mixed.basic"/>


### PR DESCRIPTION
Pull request to fix the datatype for the `@containerid` attribute on `<container>`.

Fix is in inprocess/ead_revised_defs.rng. I manually updated ead3.rng, but all derivatives will need to be regenerated.